### PR TITLE
Add missing types for prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "@types/inquirer-fuzzy-path": "^2.3.9",
                 "@types/jest": "^29.5.12",
                 "@types/node": "^20.11.27",
+                "@types/prettier": "^2.7.3",
                 "babel-jest": "^29.7.0",
                 "esbuild": "^0.20.2",
                 "jest": "^29.7.0",
@@ -2855,6 +2856,12 @@
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
+        },
+        "node_modules/@types/prettier": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+            "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+            "dev": true
         },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@types/inquirer-fuzzy-path": "^2.3.9",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.27",
+        "@types/prettier": "^2.7.3",
         "babel-jest": "^29.7.0",
         "esbuild": "^0.20.2",
         "jest": "^29.7.0",


### PR DESCRIPTION
Tests inside `src/cli.test.ts` I was getting errors like the following:
```bash
Test the cli commands › should log error message if incorrect depthLimit argument is passed

    expect(received).toEqual(expected) // deep equality

    - Expected  -  2
    + Received  + 19

    -
    - Please provide a valid argument for depth limit
    + /Users/antoniom/Development/typescript/react-add-new/node_modules/ts-node/src/index.ts:859
    +     return new TSError(diagnosticText, diagnosticCodes, diagnostics);
    +            ^
    + TSError: ⨯ Unable to compile TypeScript:
    + src/utils/formatting/prettify.ts(1,22): error TS7016: Could not find a declaration file for module 'prettier'. '/Users/antoniom/Development/typescript/react-add-new/node_modules/prettier/index.js' implicitly has an 'any' type.
    +   Try `npm i --save-dev @types/prettier` if it exists or add a new declaration (.d.ts) file containing `declare module 'prettier';`
    +
    +     at createTSError (/Users/antoniom/Development/typescript/react-add-new/node_modules/ts-node/src/index.ts:859:12)
    +     at reportTSError (/Users/antoniom/Development/typescript/react-add-new/node_modules/ts-node/src/index.ts:863:19)
    +     at getOutput (/Users/antoniom/Development/typescript/react-add-new/node_modules/ts-node/src/index.ts:1077:36)
    +     at Object.compile (/Users/antoniom/Development/typescript/react-add-new/node_modules/ts-node/src/index.ts:1433:41)
    +     at Module.m._compile (/Users/antoniom/Development/typescript/react-add-new/node_modules/ts-node/src/index.ts:1617:30)
    +     at Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    +     at Object.require.extensions.<computed> [as .ts] (/Users/antoniom/Development/typescript/react-add-new/node_modules/ts-node/src/index.ts:1621:12)
    +     at Module.load (internal/modules/cjs/loader.js:950:32)
    +     at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    +     at Module.require (internal/modules/cjs/loader.js:974:19) {
    +   diagnosticCodes: [ 7016 ]
    + }
```
This PR adds type support for the prettier (2.x) package that is used in the project