### PR TITLE
Fix/include types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
     "version": "1.2.0",
     "description": "A CLI tool to create new React components",
     "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "scripts": {
         "test": "jest --runInBand",
         "clean": "rimraf dist",
-        "build": "npm run clean && esbuild src/index.ts src/cli.ts --bundle --platform=node --outdir=dist --packages=external",
+        "build": "npm run clean && esbuild src/index.ts src/cli.ts --bundle --platform=node --outdir=dist --packages=external && tsc",
         "prepublishOnly": "npm run build"
     },
     "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,11 @@
         "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
         "strict": true /* Enable all strict type-checking options. */,
         "skipLibCheck": true /* Skip type checking all .d.ts files. */,
-        "resolveJsonModule": true /* Allows importing modules with a .json */
+        "resolveJsonModule": true /* Allows importing modules with a .json */,
+        "declaration": true /* Generate d.ts files */,
+        "emitDeclarationOnly": true /* Generate d.ts files only (no other processing should be done by the compiler) */,
+        "rootDir": "./src" /* Specifies the source code's root dir */
     },
-    "include": ["src"]
+    "include": ["src"],
+    "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
This PR adds type support for the exposed functions mentioned in #3.

In brief:
 - It appears that esbuild does not [natively support](https://github.com/evanw/esbuild/issues/95#issuecomment-626069971) type generation
 - There are [other](https://www.npmjs.com/package/esbuild-plugin-d.ts) [plugins](https://www.npmjs.com/package/npm-dts) that can generate d.ts files but require extra dep instalation.
 - Since tsc is also available in the project I utilized its functionality for creating that .d.ts file
 - Unfortunately I couldn't bundle all types inside index.d.ts. This is because we are importing package.json inside our code (see #6) and this conflicts with `rootDir`. There are solutions to this but are either complicated or require to transition the package into ESM.